### PR TITLE
Add support for setting manual device in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ processing:
   remove_filler_words: true   # Remove "um", "uh", etc.
   auto_capitalize: true       # Capitalize first letter of sentences
   auto_punctuate: false       # Auto-add punctuation (experimental)
+
+# Manual device selection
+input_device: "/dev/input/event25"
 ```
 
 **Quick config changes:**
@@ -259,6 +262,8 @@ curl -L -o ggml-base.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/ma
 ### Virtual keyboard detected instead of real keyboard
 The daemon automatically filters out virtual devices (ydotoold, xdotool).
 If issues persist, check logs with `run-daemon-debug` to see which devices are detected.
+
+As a last resort you can manually set your input device in the configuration.
 
 ### Language not detected correctly
 ```bash

--- a/src/whisper_dictation/config.py
+++ b/src/whisper_dictation/config.py
@@ -14,6 +14,7 @@ class Config:
 
     DEFAULT_CONFIG = {
         "hotkey": {"modifiers": ["super"], "key": "period"},  # super, ctrl, alt, shift
+        "input_device": None,  # Optional: manually specify device name or path (e.g. "logitech", "/dev/input/event3")
         "whisper": {"model": "medium", "language": "en", "threads": 4},
         "ui": {"show_waveform": False, "theme": "dark"},  # Not implemented yet
         "processing": {
@@ -60,6 +61,10 @@ class Config:
             with open(self.config_path, "w") as f:
                 yaml.dump(self.DEFAULT_CONFIG, f, default_flow_style=False)
             return self.DEFAULT_CONFIG.copy()
+
+    def get_input_device(self) -> str | None:
+        """Get configured input device name or path"""
+        return self.config.get("input_device")
 
     def get_hotkey_modifiers(self) -> list[int]:
         """Get list of modifier keycodes"""

--- a/src/whisper_dictation/config.py
+++ b/src/whisper_dictation/config.py
@@ -22,6 +22,11 @@ class Config:
             "auto_capitalize": True,
             "auto_punctuate": False,
         },
+        "typing": {
+            "key_delay": 0,
+            "key_hold": 0,
+            "start_delay": 0.3,
+        },
     }
 
     # Map modifier names to ecodes

--- a/src/whisper_dictation/daemon.py
+++ b/src/whisper_dictation/daemon.py
@@ -69,15 +69,30 @@ class DictationDaemon:
         # Prefer keyboards with "keyboard" in the name
         for device, path in candidates:
             if "keyboard" in device.name.lower():
-                logger.info(f"Selected keyboard: {device.name} at {path}")
+                logger.info(f"Auto-selected keyboard: {device.name} at {path}")
                 return device
+        
         # Otherwise return the first candidate
         device, path = candidates[0]
-        logger.info(f"Selected first candidate: {device.name} at {path}")
+        logger.info(f"Auto-selected first candidate: {device.name} at {path}")
         return device
 
     def find_keyboard_device(self):
         """Find the main keyboard device that supports our hotkey"""
+        # Check for manual configuration
+        configured_device = self.config.get_input_device()
+        if configured_device:
+            logger.info(f"Looking for configured device: {configured_device}")
+            for device_path in list_devices():
+                try:
+                    device = InputDevice(device_path)
+                    if configured_device in device.name or configured_device == device_path:
+                        logger.info(f"Found configured device: {device.name} at {device_path}")
+                        return device
+                except (OSError, PermissionError):
+                    continue
+            logger.warning(f"Configured device '{configured_device}' not found! Falling back to auto-detection.")
+
         candidates = []
 
         for device_path in list_devices():

--- a/src/whisper_dictation/paste.py
+++ b/src/whisper_dictation/paste.py
@@ -36,10 +36,15 @@ class TextPaster:
 
         try:
             # Small delay to ensure window focus
-            time.sleep(0.3)
+            time.sleep(self.config.get("typing.start_delay", 0.3))
 
             # Use ydotool to type text
-            subprocess.run(["ydotool", "type", text], check=True)
+            key_delay = str(self.config.get("typing.key_delay", 20))
+            key_hold = str(self.config.get("typing.key_hold", 20))
+            subprocess.run(
+                ["ydotool", "type", "--key-delay", key_delay, "--key-hold", key_hold, text],
+                check=True,
+            )
 
             logger.info("Text pasted successfully")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,9 +38,11 @@ whisper:
     assert config.get("whisper.language") == "es"
 
 
-def test_hotkey_display():
+def test_hotkey_display(tmp_path):
     """Test hotkey display string generation"""
-    config = Config()
+    # Use valid config path to avoid loading from ~/.config
+    config_path = tmp_path / "config.yaml"
+    config = Config(config_path)
 
     display = config.get_hotkey_display()
 

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -34,6 +34,10 @@ def test_paste_text(mock_run, paster):
 
     assert "ydotool" in call_args
     assert "type" in call_args
+    assert "--key-delay" in call_args
+    assert "0" in call_args  # Default key_delay
+    assert "--key-hold" in call_args
+    assert "0" in call_args  # Default key_hold
     assert text in call_args
 
 


### PR DESCRIPTION
I ran into the issue where my keyboard was actually a virtual one. 
This seemed like the cleanest option to solve the issue.
